### PR TITLE
docs(management): データインフラ構築タスクのブレイクダウン

### DIFF
--- a/docs/03_management/tasks.md
+++ b/docs/03_management/tasks.md
@@ -179,7 +179,11 @@ Status: `[/]` 進行中
   - [x] **[準備]** 初期データ移行スクリプトの作成
     - [x] ローカルMDXファイルの解析 (Frontmatter + 本文)
     - [x] 本文データの R2 へのアップロード (完了)
-    - [ ] メタデータおよびEmbeddingの Turso への INSERT
+    - [ ] マスタデータ（Composer, Works）の生成ワークフロー実装（Json at GitHub）
+    - [ ] マスタデータのTursoへのINSERTワークフロー実装
+    - [ ] ArticleメタデータのTursoへのINSERTワークフロー実装
+    - [ ] 検索のためのEmbeddingの生成ワークフロー実装
+    - [ ] EmbeddingのTursoへのINSERTワークフロー実装
 
 - [x] **5.7 STEP 2: インフラ層の実装 (Infrastructure Layer)**
   - [x] **[実装]** Clientセットアップ


### PR DESCRIPTION
## 概要
データインフラ構築タスクを詳細なサブタスクに分割しました。

## 変更点
- tasks.mdの「データインフラの物理構築」タスクを、実行可能な5つのサブタスクに具体化しました。

## 確認方法
- tasks.mdの差分確認