### PR TITLE
fix(config): enforce .env.local usage and ignore env.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+env.local
 
 # static build artifacts
 /public/pagefind


### PR DESCRIPTION
# Summary

誤った環境変数ファイル名 `env.local` を正しい `.env.local` に修正し、Gitの管理対象から適切に除外されるように `.gitignore` を更新しました。
これにより、機密情報が含まれるローカル環境変数が誤ってコミットされるリスクを防ぎます。
また、機密情報を含む `.env.local` ファイル自体はコミットせず、`.gitignore` の変更のみを適用しています。

# Related Issues

- (なし)

# Verification Plan

- [x] **Manual Verification:**
  - [x] Localhost での動作確認 (環境変数の読み込み確認)
- [x] **Automated Tests:**
  - [x] Unit Tests (`pnpm run test`) passed
  - [x] Lint / TypeCheck (`pnpm run type-check`) passed
- [x] **Evidence:**
  - [x] `git check-ignore -v env.local` による検証済み

# Guidelines Check

- [x] `docs/02_guidelines/naming-conventions.md` (命名規則)
- [x] `docs/02_guidelines/development-guidelines.md` (ディレクトリ構成・責務)
- [x] `docs/02_guidelines/localization-guidelines.md` (多言語・文言)
