### PR TITLE
feat: middleware.tsからproxy.tsへの移行対応 (#148)

### DIFF
--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -10,7 +10,7 @@ export const authConfig = {
   callbacks: {
     /**
      * ルーティングごとの認可チェック
-     * Middleware で使用される
+     * Proxy で使用される
      */
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ import { APP_ENV } from '@/lib/constants';
 const intlMiddleware = createMiddleware(routing);
 
 /**
- * Auth + i18n Middleware
+ * Auth + i18n Proxy
  *
  * auth() でラップすることで、authConfig.callbacks.authorized が実行される。
  * その後、第2引数の callback に処理が渡る。
@@ -15,7 +15,7 @@ const intlMiddleware = createMiddleware(routing);
  * 言語判定・リダイレクト・パスの書き換えはすべて next-intl に任せます。
  * これにより、ロケールなしのパス（例: /about）が正しく /en/about へ誘導されます。
  */
-export default auth((req) => {
+export const proxy = auth((req) => {
   // FIXME: next-auth の NextAuthRequest と next-intl が期待する NextRequest の間に、
   // Next.js のマイナーバージョン差異に起因する内部型の不整合があるため、unknown を経由してキャストしています。
   // 将来的にライブラリ側の型定義が更新されたら直接渡せるようになるはずです。
@@ -73,7 +73,7 @@ export default auth((req) => {
 
 export const config = {
   // API, _next, _vercel, 静的ファイル(拡張子あり)を除外してすべてにマッチさせる
-  // Note: この設定により、URLパスに「.」を含むページ（例: /works/op.55）はミドルウェアの対象外となります。
+  // Note: この設定により、URLパスに「.」を含むページ（例: /works/op.55）はProxyの対象外となります。
   // そのため、スラグには「.」を使用しない運用（kebab-case）を徹底してください。
   matcher: [
     {


### PR DESCRIPTION
# Summary

Next.js 16 における `middleware.ts` ファイル規約の非推奨化に伴い、推奨される `proxy.ts` への移行を実施しました。

- `src/middleware.ts` を `src/proxy.ts` へリネーム
- エクスポート形式を `export default auth(...)` から `export const proxy = auth(...)` へ変更 (Auth.js v5 の推奨パターン)
- 関連するコメント内の「Middleware」表記を「Proxy」へ更新

# Related Issues

- closes #148

# Verification Plan (How strictly verified?)

- [x] **Manual Verification:**
  - [x] Localhost での動作確認 (ビルド出力に `ƒ Proxy (Middleware)` が表示されることを確認)
- [x] **Automated Tests:**
  - [x] Unit Tests (`pnpm run test`) passed
  - [x] Lint / TypeCheck (`pnpm run lint`, `pnpm run type-check`) passed
- [x] **Evidence:**
  - [x] `pnpm build` が正常終了し、Proxyが認識されていることをログで確認済み。

# Guidelines Check

- [x] `docs/02_guidelines/naming-conventions.md` (命名規則)
- [x] `docs/02_guidelines/development-guidelines.md` (ディレクトリ構成・責務)
- [x] `docs/02_guidelines/localization-guidelines.md` (多言語・文言)